### PR TITLE
Adicionando configuração de CI ao projeto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,12 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Build project
-        run: yarn build
-        
-      - name: Save build folder
+     - name: Save cache folder
         uses: actions/upload-artifact@v4
         with:
-          name: build
-          path: build
+          name: cache
+          if-no-files-found: error
+          path: cypress/cache
 
   api-test:
     runs-on: ubuntu-latest
@@ -34,11 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download the build folder
+      - name: Download the cache folder
         uses: actions/download-artifact@v4
         with:
-          name: build
-          path: build
+          name: cache
+          path: cypress/cache
 
       - name: Run API Test
         run: yarn cy:api
@@ -50,11 +48,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download the build folder
+      - name: Download the cache folder
         uses: actions/download-artifact@v4
         with:
-          name: build
-          path: build
+          name: cache
+          path: cypress/cache
 
       - name: Run E2E Test
         run: yarn cy:e2e --browser chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
+        uses: cypress-io/github-action@v6
         run: yarn install
 
       - name: Create cache directory
@@ -45,6 +46,7 @@ jobs:
           path: cypress/cache
 
       - name: Run API Test
+        
         run: yarn cy:api
 
   e2e-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Node install
         uses: actions/setup-node@v2
         with:
-          node-version: '19'
+          node-version: '20'
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Build project
+        run: yarn build
+        
       - name: Save build folder
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-     - name: Save cache folder
+      - name: Save cache folder
         uses: actions/upload-artifact@v4
         with:
           name: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: ServeRest Cypress Tests
+
+on: 
+  push:
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Node install
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Save build folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build
+
+  api-test:
+    runs-on: ubuntu-latest
+    needs: dependencies
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download the build folder
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build
+
+      - name: Run API Test
+        run: yarn cy:api
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: dependencies
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download the build folder
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build
+
+      - name: Run E2E Test
+        run: yarn cy:e2e --browser chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Create cache directory
+        run: mkdir -p cypress/cache
+
+      - name: Copy Yarn cache
+        run: cp -R $(yarn cache dir)/* cypress/cache/
+
       - name: Save cache folder
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ServeRest Cypress Tests
 
-name: ServeRest Cypress Tests
-
 on:
   push:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Node install
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '19'
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,28 @@
 name: ServeRest Cypress Tests
 
-on: 
+name: ServeRest Cypress Tests
+
+on:
   push:
 
 jobs:
-  dependencies:
+  cypress-tests:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Node install
-        uses: actions/setup-node@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: 20
 
       - name: Install dependencies
-        uses: cypress-io/github-action@v6
         run: yarn install
 
-      - name: Create cache directory
-        run: mkdir -p cypress/cache
-
-      - name: Copy Yarn cache
-        run: cp -R $(yarn cache dir)/* cypress/cache/
-
-      - name: Save cache folder
-        uses: actions/upload-artifact@v4
-        with:
-          name: cache
-          if-no-files-found: error
-          path: cypress/cache
-
-  api-test:
-    runs-on: ubuntu-latest
-    needs: dependencies
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download the cache folder
-        uses: actions/download-artifact@v4
-        with:
-          name: cache
-          path: cypress/cache
-
-      - name: Run API Test
-        
+      - name: Run API tests
         run: yarn cy:api
 
-  e2e-test:
-    runs-on: ubuntu-latest
-    needs: dependencies
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download the cache folder
-        uses: actions/download-artifact@v4
-        with:
-          name: cache
-          path: cypress/cache
-
-      - name: Run E2E Test
-        run: yarn cy:e2e --browser chrome
+      - name: Run E2E tests
+        run: yarn cy:e2e


### PR DESCRIPTION
## Por que esta mudança é necessária?

Adicionando configuração de CI simples ao projeto.

---

## O que foi feito?

1. Adicionado workflow de CI simples para melhorar a qualidade do projeto.

Exemplo de [pipeline](https://github.com/lucas-scandido/desafio-qa-ntt-ambev/actions/runs/12935784911/job/36079901846)

![{720D5590-634A-4855-92E9-753ABE4584B9}](https://github.com/user-attachments/assets/de027207-3850-42f9-a20f-9aa9d315d24f)

 

